### PR TITLE
Fix logging

### DIFF
--- a/logging/middleware_test.go
+++ b/logging/middleware_test.go
@@ -81,7 +81,7 @@ func TestActivityLogger(t *testing.T) {
 
 		wg := &sync.WaitGroup{}
 		d := &dummyLogFile{Wg: wg}
-		r.Use(ActivityLogger(d, func(_ *gin.Context) (interface{}, error) {
+		r.Use(ActivityLogger(d, func(_ *gin.Context) (string, error) {
 			return "testUserID", nil
 		}))
 
@@ -142,7 +142,7 @@ func TestActivityLogger(t *testing.T) {
 			So(al.Status, ShouldEqual, 200)
 			So(al.UserAgent, ShouldEqual, req.Header.Get("User-Agent"))
 			So(al.Latency, ShouldBeGreaterThan, 0)
-			So(al.RequestBody["test"], ShouldBeTrue)
+			So(al.RequestBody, ShouldEqual, "{\"test\": true}")
 			So(al.Extra, ShouldEqual, "testUserID")
 		})
 

--- a/logging/model.go
+++ b/logging/model.go
@@ -25,6 +25,6 @@ type AccessLog struct {
 // ActivityLog is a log information of user action
 type ActivityLog struct {
 	LogInfo
-	RequestBody map[string]interface{} `json:"requestBody,omitempty"`
-	Extra       interface{}            `json:"extra,omitempty"`
+	RequestBody string `json:"requestBody,omitempty"`
+	Extra       string `json:"extra,omitempty"`
 }

--- a/logging/util.go
+++ b/logging/util.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"time"
 
-	"encoding/json"
 	"github.com/gin-gonic/gin"
 )
 
@@ -26,7 +25,8 @@ func GenerateLogInfo(c *gin.Context, start time.Time) LogInfo {
 }
 
 // ConvertToMapFromBody converts to a map from a request body
-func ConvertToMapFromBody(c *gin.Context) (m map[string]interface{}, err error) {
+func ConvertToMapFromBody(c *gin.Context) (s string, err error) {
+
 	b, err := ioutil.ReadAll(c.Request.Body)
 	if err != nil {
 		return
@@ -34,7 +34,7 @@ func ConvertToMapFromBody(c *gin.Context) (m map[string]interface{}, err error) 
 	c.Request.Body = ioutil.NopCloser(bytes.NewBuffer(b))
 
 	if len(b) != 0 {
-		err = json.Unmarshal(b, &m)
+		s = string(b)
 	}
 	return
 }


### PR DESCRIPTION
- BigQueryに対応するよう、`RequestBody`, `Extra`をstringに変更
  - 中身が可変する為
- Recover用のfunctionの引数に`gin.Context`を必須に
  - Recoverする時にユーザ情報などを引き継ぐ為